### PR TITLE
Enable changing font family

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@types/lodash": "^4.14.118",
+    "font-manager": "^0.3.0",
     "lodash": "^4.17.11",
     "monaco-editor": "0.14.3",
     "monaco-vim": "^0.0.7",

--- a/src/App.vue
+++ b/src/App.vue
@@ -136,6 +136,7 @@ export default class App extends Vue {
       automaticLayout: true,
       autoIndent: true,
       fontSize: this.persisted.fontSize,
+      fontFamily: this.persisted.fontFamily,
       language: this.persisted.language,
       wordWrap: 'on',
       lineDecorationsWidth: 0,
@@ -203,6 +204,13 @@ export default class App extends Vue {
   updateFontSize(value: number) {
     if (this.editor) {
       this.editor.updateOptions({ fontSize: this.persisted.fontSize })
+    }
+  }
+
+  @Watch('persisted.fontFamily')
+  updateFontFamily(value: string) {
+    if (this.editor) {
+      this.editor.updateOptions({ fontFamily: this.persisted.fontFamily })
     }
   }
 }

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -145,7 +145,7 @@ body {
   .select-group {
     display: flex;
     label {
-      width: 60px;
+      width: 80px;
     }
   }
 

--- a/src/components/Preferences.vue
+++ b/src/components/Preferences.vue
@@ -37,6 +37,14 @@
           </option>
         </select>
       </div>
+      <div class="form-group select-group">
+        <label>Font Family:</label>
+        <select v-model="persisted.fontFamily">
+          <option v-for="font in fontFamilies" :value="font" :key="font">
+            {{ font }}
+          </option>
+        </select>
+      </div>
       <div class="app-version">エディ太郎: {{ appVersion }}</div>
     </div>
   </div>
@@ -53,6 +61,7 @@ import '../lib/theme/dark-grad'
 import '../lib/theme/light-grad'
 import themes from '../lib/theme/themes'
 import { remote } from 'electron'
+import fontFamilies from '../lib/fontFamilies'
 
 interface IEditorModes {
   value: IEditorMode
@@ -74,6 +83,7 @@ export default class extends Vue {
   themes = themes
   appVersion = remote.app.getVersion()
   fontSizes: number[] = range(10, 101)
+  fontFamilies = fontFamilies
 
   close() {
     this.memory.showPreferences = false

--- a/src/font-manager.d.ts
+++ b/src/font-manager.d.ts
@@ -1,0 +1,14 @@
+declare module 'font-manager' {
+  export function findFontsSync(
+    param: any
+  ): {
+    path: string
+    postscriptName: string
+    family: string
+    style: string
+    weight: number
+    width: number
+    italic: boolean
+    monospace: boolean
+  }[]
+}

--- a/src/lib/fontFamilies.ts
+++ b/src/lib/fontFamilies.ts
@@ -1,0 +1,3 @@
+import * as fontManager from 'font-manager'
+const fonts = fontManager.findFontsSync({ monospace: true })
+export default fonts.map(font => font['postscriptName']).sort()

--- a/src/store.ts
+++ b/src/store.ts
@@ -12,6 +12,7 @@ export interface IPersistedStore {
   state: {
     editorMode: IEditorMode
     fontSize: number
+    fontFamily: string
     language: string
     text: string
     theme: string
@@ -30,6 +31,7 @@ const persistedStore: IPersistedStore = {
   state: {
     editorMode: 'normal',
     fontSize: 13,
+    fontFamily: '',
     language: 'markdown',
     text: '',
     theme: 'dark-grad',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3725,6 +3725,12 @@ follow-redirects@^1.0.0:
   dependencies:
     debug "=3.1.0"
 
+font-manager@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/font-manager/-/font-manager-0.3.0.tgz#9efdc13e521a3d8752e7ab56c3938818043a311f"
+  dependencies:
+    nan ">=2.10.0"
+
 for-in@^0.1.3:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"
@@ -5693,7 +5699,7 @@ mute-stream@0.0.7, mute-stream@~0.0.4:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.10.0, nan@^2.9.2:
+nan@>=2.10.0, nan@^2.10.0, nan@^2.9.2:
   version "2.11.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766"
 


### PR DESCRIPTION
Hi @kkosuge 

Editaro is my best editor for writing draft. I'm so happy to using this.
Only one missing is settings for font family.

This PR adds feature for chainging font family.

![2018-11-20 17 34 47](https://user-images.githubusercontent.com/12584878/48760927-ba7c2280-ecea-11e8-95ed-3ab7badd4f15.png)


![2018-11-20 17 35 09](https://user-images.githubusercontent.com/12584878/48760933-bd771300-ecea-11e8-8089-0f361a0783bc.png)

I have confirmed that this PR works with `yarn serve:electron` with macOS HighSierra.
However when I try to build for  production. below error shows and i could not build the app.
Do you have any idea/solution?
Thanks!

エディ太郎とっても気に入っています！
フォントを変えれたらいいなと思ってPR出しましたが、ビルドできずに困っています。。
ふだんTypeScript / Electronを書かないので、おかしなところあれば指摘していただけますと助かります！