### PR TITLE
Avoid invoking `mainWindow` operations when `mainWindow` is falsey

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -114,28 +114,28 @@ function createMainWindow() {
           label: 'Reload',
           accelerator: 'CmdOrCtrl+R',
           click: function() {
-            mainWindow.reload()
+            if (mainWindow) mainWindow.reload()
           },
         },
         {
           label: 'Close',
           accelerator: 'CmdOrCtrl+W',
           click: function() {
-            mainWindow.close()
+            if (mainWindow) mainWindow.close()
           },
         },
         {
           label: 'Toggle Full Screen',
           accelerator: process.platform === 'darwin' ? 'Ctrl+Command+F' : 'F11',
           click: function() {
-            mainWindow.setFullScreen(!mainWindow.isFullScreen())
+            if (mainWindow) mainWindow.setFullScreen(!mainWindow.isFullScreen())
           },
         },
         {
           label: 'Toggle Developer Tools',
           accelerator: process.platform === 'darwin' ? 'Alt+Cmd+I' : 'Ctrl+Shift+I',
           click: function() {
-            mainWindow.toggleDevTools()
+            if (mainWindow) mainWindow.toggleDevTools()
           },
         },
       ],


### PR DESCRIPTION
勢い余って Cmd + W を 2 回押してしまったときなどに下記のようなエラーが出るので、他の行にあるように `if (mainWindow)` があるといいのではないかと思いました。
よければご検討ください:pray:
![スクリーンショット 2019-07-25 11 06 08](https://user-images.githubusercontent.com/943695/61840540-70c48700-aecc-11e9-99f3-380024ba0639.png)
