### PR TITLE
Add shortcut-key for opening Command Palette

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -105,6 +105,11 @@ export default class App extends Vue {
       this.persisted.fontSize -= 1
     })
 
+    ipcRenderer.on('openCommandPalette', () => {
+      if (this.editor)
+        this.editor.trigger('App', 'editor.action.quickCommand', null)
+    })
+
     this.updateEditorMode(this.persisted.editorMode)
 
     window.addEventListener(

--- a/src/background.ts
+++ b/src/background.ts
@@ -138,6 +138,13 @@ function createMainWindow() {
             if (mainWindow) mainWindow.toggleDevTools()
           },
         },
+        {
+          label: 'Open Command Palette',
+          accelerator: process.platform === 'darwin' ? 'Cmd+P' : 'Ctrl+P',
+          click: function() {
+            if (mainWindow) mainWindow.webContents.send('openCommandPalette')
+          },
+        },
       ],
     },
     {

--- a/src/background.ts
+++ b/src/background.ts
@@ -140,7 +140,7 @@ function createMainWindow() {
         },
         {
           label: 'Open Command Palette',
-          accelerator: process.platform === 'darwin' ? 'Cmd+P' : 'Ctrl+P',
+          accelerator: 'CmdOrCtrl+P',
           click: function() {
             if (mainWindow) mainWindow.webContents.send('openCommandPalette')
           },

--- a/src/background.ts
+++ b/src/background.ts
@@ -140,7 +140,7 @@ function createMainWindow() {
         },
         {
           label: 'Open Command Palette',
-          accelerator: 'CmdOrCtrl+P',
+          accelerator: process.platform === 'darwin' ? 'Cmd+Shift+P' : 'Ctrl+Shift+P',
           click: function() {
             if (mainWindow) mainWindow.webContents.send('openCommandPalette')
           },


### PR DESCRIPTION
fix #5 

VSCode だと `Cmd+Shift+P` でしたが， Issue の要望通り `Cmd+P` で実装しました．
VSCode のノリで Command Palette 出したいので統一したほうがいいのかもなと思いました．