### PR TITLE
Adding feature for changing tab size

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -215,5 +215,12 @@ export default class App extends Vue {
       this.editor.updateOptions({ fontFamily: this.persisted.fontFamily })
     }
   }
+
+  @Watch('persisted.tabSize')
+  updateTab(value: number) {
+    if (this.editorModel) {
+      this.editorModel.updateOptions({ tabSize: this.persisted.tabSize })
+    }
+  }
 }
 </script>

--- a/src/components/Preferences.vue
+++ b/src/components/Preferences.vue
@@ -42,6 +42,12 @@
           </optgroup>
         </select>
       </div>
+      <div class="form-group select-group">
+        <label>Tab Size:</label>
+        <select v-model="persisted.tabSize">
+          <option v-for="size in tabSizes" :value="size" :key="size">{{ size }}</option>
+        </select>
+      </div>
       <div class="app-version">エディ太郎: {{ appVersion }}</div>
     </div>
   </div>
@@ -84,6 +90,7 @@ export default class extends Vue {
   themes = themes
   appVersion = remote.app.getVersion()
   fontSizes: number[] = range(10, 101)
+  tabSizes: number[] = range(1, 11)
   fontFamilies = fontFamilies
 
   close() {

--- a/src/store.ts
+++ b/src/store.ts
@@ -13,6 +13,7 @@ export interface IPersistedStore {
     editorMode: IEditorMode
     fontSize: number
     fontFamily: string
+    tabSize: number
     language: string
     text: string
     theme: string
@@ -32,6 +33,7 @@ const persistedStore: IPersistedStore = {
     editorMode: 'normal',
     fontSize: 13,
     fontFamily: '',
+    tabSize: 4,
     language: 'markdown',
     text: '',
     theme: 'dark-grad',


### PR DESCRIPTION
タブのサイズを選択できるようにしました

<img width="864" alt="スクリーンショット 2019-11-01 17 29 11" src="https://user-images.githubusercontent.com/1137860/68012366-2cb40000-fccd-11e9-893a-03db46472d86.png">

タブのサイズ変更欄をテキストエリアにしようとやってみましたが、テキストエリア内で削除した際にフリーズした感じになってしまいますね。普段Vue.js使うコード書いてないので改善方法が思いつかず、セレクトタグを使ってます。
