### PR TITLE
chore: specify node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
   "prettier": {
     "semi": false,
     "singleQuote": true
+  },
+  "engines": {
+    "node": "^10.0.0"
   }
 }


### PR DESCRIPTION
Build failed using node@12, so specify node engine as 10.