### PR TITLE
Add Quick Suggestions option

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -154,6 +154,7 @@ export default class App extends Vue {
       minimap: {
         enabled: false,
       },
+      quickSuggestions: this.persisted.quickSuggestions,
     }
 
     if (this.persisted.fontFamily.length) {
@@ -234,6 +235,15 @@ export default class App extends Vue {
   updateTab(value: number) {
     if (this.editorModel) {
       this.editorModel.updateOptions({ tabSize: this.persisted.tabSize })
+    }
+  }
+
+  @Watch('persisted.quickSuggestions')
+  updateQuickSuggestions(value: boolean) {
+    if (this.editor) {
+      this.editor.updateOptions({
+        quickSuggestions: this.persisted.quickSuggestions,
+      })
     }
   }
 }

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -149,7 +149,7 @@ body {
   .select-group {
     display: flex;
     label {
-      width: 80px;
+      width: 120px;
     }
   }
 

--- a/src/components/Preferences.vue
+++ b/src/components/Preferences.vue
@@ -64,6 +64,14 @@
           }}</option>
         </select>
       </div>
+      <div class="form-group select-group">
+        <label>Quick Suggestions:</label>
+        <input
+          type="checkbox"
+          id="checkbox"
+          v-model="persisted.quickSuggestions"
+        />
+      </div>
       <div class="app-version">エディ太郎: {{ appVersion }}</div>
     </div>
   </div>

--- a/src/store.ts
+++ b/src/store.ts
@@ -17,6 +17,7 @@ export interface IPersistedStore {
     language: string
     text: string
     theme: string
+    quickSuggestions: boolean
   }
   load(): void
   watch(vm: Vue, key: 'persisted'): any
@@ -37,6 +38,7 @@ const persistedStore: IPersistedStore = {
     language: 'markdown',
     text: '',
     theme: 'dark-grad',
+    quickSuggestions: true,
   },
 
   load() {


### PR DESCRIPTION
I've added a new option to the Preferences page because it's easier to use with Quick Suggestions disabled when writing small notes.

![image](https://user-images.githubusercontent.com/19500280/103457589-f7c59200-4d43-11eb-9880-885f45f7a37b.png)
